### PR TITLE
config: Use dex2oat64 on 64-bit-only builds

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -146,6 +146,10 @@ PRODUCT_PACKAGES += \
     SimpleDeviceConfig \
     SimpleSettingsConfig
 
+# Dalvik
+PRODUCT_VENDOR_PROPERTIES += \
+    dalvik.vm.dex2oat64.enabled?=$(TARGET_SUPPORTS_64_BIT_APPS)
+
 # Extra tools in Lineage
 PRODUCT_PACKAGES += \
     bash \


### PR DESCRIPTION
dexopt defaults to dex2oat32 unless instructed otherwise. Since dex2oat32 doesn't exist on a 64-bit-only build, make sure dex2oat64 is selected instead.

Test: boot aosp_cf_x86_64_only_phone and check that installd doesn't
  try to use dex2oat32
Change-Id: Ia67e746894684a52a4e5b765bfde0f6dd0efbf6e

* Conditionally enable 64Bit dex2oat someone5678 <someone5678@users.noreply.github.com>